### PR TITLE
Skip when it is current password

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 0.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix can not change weak password
+  [ivanteoh]
 
 
 0.4 (2015-06-05)

--- a/Products/PasswordStrength/plugin.py
+++ b/Products/PasswordStrength/plugin.py
@@ -224,12 +224,13 @@ def validate(self, value):
         return
 
     skip = False
+    # Do not validate existing passwords
+    if getattr(self, '__name__', '') == 'current_password':
+        skip = True
+
     if IPasswordSchema.providedBy(self.context):
         # We need to get the context's context
         context = self.context.context
-        # Do not validate existing passwords
-        if getattr(self, '__name__', '') == 'current_password':
-            skip = True
     else:
         context = self.context
     if not skip:


### PR DESCRIPTION
Fix issue https://github.com/collective/Products.PasswordStrength/issues/8

`IPasswordSchema.providedBy(self.context)` is false when the object is 'current password'.