### PR TITLE
Disable password strength validation on /login

### DIFF
--- a/Products/PasswordStrength/plugin.py
+++ b/Products/PasswordStrength/plugin.py
@@ -45,6 +45,14 @@ def generatePassword(self):
 # Monkey patch of registration tool method to avoid skipping validation for manager
 def testPasswordValidity(self, password, confirm=None):
     # We escape the test if it looks like a generated password (with default length of 56 chars)
+    site = portal.getSite()
+    request = site.REQUEST
+
+    # Check if the request URL is for the login page
+    if request and request.URL.endswith('/login'):
+        # Skip password strength validation for login requests
+        return None
+    
     if password is not None and password.startswith('G-') and len(password) == len(self.origGeneratePassword()) + 2:
         return None
     session = self.REQUEST.get('SESSION', {}) or {}


### PR DESCRIPTION
I believe password strength validation should only occur during registration or when changing the password, not during login, as it could prevent users from accessing the site.

[screen-capture (14).webm](https://github.com/user-attachments/assets/d9ec15c5-28d2-46f2-b8b6-9e7fc763d341)
